### PR TITLE
Add real function tests for issue #11

### DIFF
--- a/Rating/Functions/GetAllRatings.cs
+++ b/Rating/Functions/GetAllRatings.cs
@@ -15,7 +15,7 @@ namespace Rating.Functions
         private readonly ILogger<GetAllRatings> _logger;
 
         public GetAllRatings(
-            MongoClient mongoClient,
+            IMongoClient mongoClient,
             ILogger<GetAllRatings> logger)
         {
             _logger = logger;
@@ -30,7 +30,8 @@ namespace Rating.Functions
         {
             try
             {
-                var result = await _ratings.Find(rating => true).ToListAsync();
+                using var cursor = await _ratings.FindAsync(Builders<Model.Rating>.Filter.Empty);
+                var result = await cursor.ToListAsync();
                 var response = req.CreateResponse(HttpStatusCode.OK);
                 await response.WriteAsJsonAsync(RatingSummaries.CreateAll(result));
                 return response;

--- a/Rating/Functions/GetRating.cs
+++ b/Rating/Functions/GetRating.cs
@@ -15,7 +15,7 @@ namespace Rating.Functions
         private readonly ILogger<GetRating> _logger;
 
         public GetRating(
-            MongoClient mongoClient,
+            IMongoClient mongoClient,
             ILogger<GetRating> logger)
         {
             _logger = logger;
@@ -31,7 +31,9 @@ namespace Rating.Functions
         {
             try
             {
-                var result = await _ratings.Find(rating => rating.PersonId == id).ToListAsync();
+                var filter = Builders<Model.Rating>.Filter.Eq(rating => rating.PersonId, id);
+                using var cursor = await _ratings.FindAsync(filter);
+                var result = await cursor.ToListAsync();
                 var response = req.CreateResponse(HttpStatusCode.OK);
                 await response.WriteAsJsonAsync(RatingSummaries.CreateForPerson(id, result));
                 return response;

--- a/Rating/Functions/UpsertRating.cs
+++ b/Rating/Functions/UpsertRating.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -14,7 +15,7 @@ namespace Rating.Functions
         private readonly ILogger<UpsertRating> _logger;
 
         public UpsertRating(
-            MongoClient mongoClient,
+            IMongoClient mongoClient,
             ILogger<UpsertRating> logger)
         {
             _logger = logger;
@@ -36,7 +37,9 @@ namespace Rating.Functions
                     return req.CreateResponse(HttpStatusCode.BadRequest);
                 }
 
-                var exrating = await _ratings.Find(ex => ex.PersonId == rating.PersonId && ex.UserId == rating.UserId).FirstOrDefaultAsync();
+                var filter = Builders<Model.Rating>.Filter.Where(ex => ex.PersonId == rating.PersonId && ex.UserId == rating.UserId);
+                using var cursor = await _ratings.FindAsync(filter);
+                var exrating = (await cursor.ToListAsync()).FirstOrDefault();
 
                 if (exrating == null)
                 {

--- a/Rating/Program.cs
+++ b/Rating/Program.cs
@@ -15,7 +15,7 @@ var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices(services =>
     {
-        services.AddSingleton(_ => new MongoClient(mongoConnectionString));
+        services.AddSingleton<IMongoClient>(_ => new MongoClient(mongoConnectionString));
     })
     .Build();
 

--- a/TestRating/FunctionTests.cs
+++ b/TestRating/FunctionTests.cs
@@ -1,0 +1,359 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Serialization;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using MongoDB.Driver;
+using Rating;
+using Rating.Functions;
+using Rating.Model;
+using RatingModel = Rating.Model.Rating;
+
+namespace TestRating
+{
+    [TestClass]
+    public class FunctionTests
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        [TestMethod]
+        public async Task GetRatingReturnsAverageForRequestedPerson()
+        {
+            var ratings = new List<RatingModel>
+            {
+                new() { PersonId = 7, UserId = "a", Rate = 8 },
+                new() { PersonId = 7, UserId = "b", Rate = 4 }
+            };
+            var mongo = CreateMongoContext(ratings);
+
+            var function = new GetRating(mongo.Client.Object, Mock.Of<ILogger<GetRating>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request, 7);
+            var body = await ReadBodyAsync<ViewRating>(response);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsNotNull(body);
+            Assert.AreEqual(7, body.PersonId);
+            Assert.AreEqual(6.0, body.AverageRate);
+        }
+
+        [TestMethod]
+        public async Task GetRatingReturnsInternalServerErrorWhenQueryFails()
+        {
+            var mongo = CreateMongoContext();
+            mongo.CollectionMock
+                .Setup(x => x.FindAsync(
+                    It.IsAny<FilterDefinition<RatingModel>>(),
+                    It.IsAny<FindOptions<RatingModel, RatingModel>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new InvalidOperationException("boom"));
+
+            var function = new GetRating(mongo.Client.Object, Mock.Of<ILogger<GetRating>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request, 7);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task GetAllRatingsReturnsGroupedSummaries()
+        {
+            var ratings = new List<RatingModel>
+            {
+                new() { PersonId = 1, UserId = "a", Rate = 10 },
+                new() { PersonId = 1, UserId = "b", Rate = 6 },
+                new() { PersonId = 2, UserId = "c", Rate = 5 }
+            };
+            var mongo = CreateMongoContext(ratings);
+
+            var function = new GetAllRatings(mongo.Client.Object, Mock.Of<ILogger<GetAllRatings>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request);
+            var body = await ReadBodyAsync<List<ViewRating>>(response);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsNotNull(body);
+            Assert.AreEqual(2, body.Count);
+            Assert.AreEqual(8.0, body.Find(x => x.PersonId == 1)?.AverageRate);
+            Assert.AreEqual(5.0, body.Find(x => x.PersonId == 2)?.AverageRate);
+        }
+
+        [TestMethod]
+        public async Task GetAllRatingsReturnsInternalServerErrorWhenQueryFails()
+        {
+            var mongo = CreateMongoContext();
+            mongo.CollectionMock
+                .Setup(x => x.FindAsync(
+                    It.IsAny<FilterDefinition<RatingModel>>(),
+                    It.IsAny<FindOptions<RatingModel, RatingModel>>(),
+                    It.IsAny<CancellationToken>()))
+                .Throws(new InvalidOperationException("boom"));
+
+            var function = new GetAllRatings(mongo.Client.Object, Mock.Of<ILogger<GetAllRatings>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReturnsBadRequestWhenBodyIsNull()
+        {
+            var mongo = CreateMongoContext();
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request);
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            mongo.CollectionMock.Verify(
+                x => x.FindAsync(
+                    It.IsAny<FilterDefinition<RatingModel>>(),
+                    It.IsAny<FindOptions<RatingModel, RatingModel>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingInsertsNewRatingWhenNoExistingRecord()
+        {
+            var newRating = new RatingModel { PersonId = 9, UserId = "alex", Rate = 7 };
+            var mongo = CreateMongoContext(Array.Empty<RatingModel>());
+            mongo.CollectionMock
+                .Setup(x => x.InsertOneAsync(
+                    It.Is<RatingModel>(r => r.PersonId == 9 && r.UserId == "alex" && r.Rate == 7),
+                    null,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(newRating);
+
+            var response = await function.Run(request);
+            var body = await ReadBodyAsync<RatingModel>(response);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsNotNull(body);
+            Assert.AreEqual(9, body.PersonId);
+            Assert.AreEqual("alex", body.UserId);
+            Assert.AreEqual(7, body.Rate);
+            mongo.CollectionMock.Verify(
+                x => x.InsertOneAsync(
+                    It.Is<RatingModel>(r => r.PersonId == 9 && r.UserId == "alex" && r.Rate == 7),
+                    null,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingDeletesExistingRatingWhenRateIsZero()
+        {
+            var existing = new RatingModel { Id = "507f1f77bcf86cd799439011", PersonId = 9, UserId = "alex", Rate = 4 };
+            var update = new RatingModel { PersonId = 9, UserId = "alex", Rate = 0 };
+            var mongo = CreateMongoContext(new[] { existing });
+            mongo.CollectionMock
+                .Setup(x => x.DeleteOneAsync(It.IsAny<FilterDefinition<RatingModel>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((DeleteResult)null);
+
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(update);
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("null", bodyText);
+            mongo.CollectionMock.Verify(
+                x => x.DeleteOneAsync(It.IsAny<FilterDefinition<RatingModel>>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReplacesExistingRatingWhenRecordExists()
+        {
+            var existing = new RatingModel { Id = "507f1f77bcf86cd799439011", PersonId = 9, UserId = "alex", Rate = 4 };
+            var update = new RatingModel { PersonId = 9, UserId = "alex", Rate = 8 };
+            var mongo = CreateMongoContext(new[] { existing });
+            mongo.CollectionMock
+                .Setup(x => x.ReplaceOneAsync(
+                    It.IsAny<FilterDefinition<RatingModel>>(),
+                    It.IsAny<RatingModel>(),
+                    It.IsAny<ReplaceOptions>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((ReplaceOneResult)null);
+
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(update);
+
+            var response = await function.Run(request);
+            var body = await ReadBodyAsync<RatingModel>(response);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsNotNull(body);
+            Assert.AreEqual(existing.Id, body.Id);
+            Assert.AreEqual(8, body.Rate);
+            mongo.CollectionMock.Verify(
+                x => x.ReplaceOneAsync(
+                    It.IsAny<FilterDefinition<RatingModel>>(),
+                    It.Is<RatingModel>(r => r.Id == existing.Id && r.PersonId == 9 && r.UserId == "alex" && r.Rate == 8),
+                    It.IsAny<ReplaceOptions>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReturnsInternalServerErrorWhenDatabaseWriteFails()
+        {
+            var newRating = new RatingModel { PersonId = 9, UserId = "alex", Rate = 7 };
+            var mongo = CreateMongoContext(Array.Empty<RatingModel>());
+            mongo.CollectionMock
+                .Setup(x => x.InsertOneAsync(It.IsAny<RatingModel>(), null, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("boom"));
+
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(newRating);
+
+            var response = await function.Run(request);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+        }
+
+        private static MongoContext CreateMongoContext(IEnumerable<RatingModel> queryResults = null)
+        {
+            var collectionMock = new Mock<IMongoCollection<RatingModel>>();
+            collectionMock
+                .Setup(x => x.FindAsync(
+                    It.IsAny<FilterDefinition<RatingModel>>(),
+                    It.IsAny<FindOptions<RatingModel, RatingModel>>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TestAsyncCursor<RatingModel>(queryResults ?? Array.Empty<RatingModel>()));
+
+            var databaseMock = new Mock<IMongoDatabase>();
+            databaseMock
+                .Setup(x => x.GetCollection<RatingModel>(Settings.COLLECTION_NAME, null))
+                .Returns(collectionMock.Object);
+
+            var clientMock = new Mock<IMongoClient>();
+            clientMock
+                .Setup(x => x.GetDatabase(Settings.DATABASE_NAME, null))
+                .Returns(databaseMock.Object);
+
+            return new MongoContext(clientMock, collectionMock);
+        }
+
+        private static HttpRequestData CreateRequest(object body)
+        {
+            var context = CreateFunctionContext();
+            var response = CreateResponse(context);
+            var requestMock = new Mock<HttpRequestData>(context);
+            requestMock.SetupGet(x => x.Body).Returns(CreateBodyStream(body));
+            requestMock.SetupGet(x => x.Headers).Returns(new HttpHeadersCollection());
+            requestMock.SetupGet(x => x.Cookies).Returns(Array.Empty<IHttpCookie>());
+            requestMock.SetupGet(x => x.Url).Returns(new Uri("https://localhost/api/rating"));
+            requestMock.SetupGet(x => x.Identities).Returns(Array.Empty<ClaimsIdentity>());
+            requestMock.SetupGet(x => x.Method).Returns("GET");
+            requestMock.Setup(x => x.CreateResponse()).Returns(response);
+
+            return requestMock.Object;
+        }
+
+        private static HttpResponseData CreateResponse(FunctionContext context)
+        {
+            var responseMock = new Mock<HttpResponseData>(context);
+            responseMock.SetupProperty(x => x.StatusCode);
+            responseMock.SetupProperty(x => x.Body, new MemoryStream());
+            responseMock.SetupGet(x => x.Headers).Returns(new HttpHeadersCollection());
+            responseMock.SetupGet(x => x.Cookies).Returns(Mock.Of<HttpCookies>());
+
+            return responseMock.Object;
+        }
+
+        private static FunctionContext CreateFunctionContext()
+        {
+            var services = new ServiceCollection();
+            services
+                .AddOptions<WorkerOptions>()
+                .Configure(options => options.Serializer = new JsonObjectSerializer());
+            var serviceProvider = services.BuildServiceProvider();
+
+            var contextMock = new Mock<FunctionContext>();
+            contextMock.SetupProperty(x => x.InstanceServices, serviceProvider);
+
+            return contextMock.Object;
+        }
+
+        private static MemoryStream CreateBodyStream(object body)
+        {
+            var json = JsonSerializer.Serialize(body);
+            return new MemoryStream(Encoding.UTF8.GetBytes(json));
+        }
+
+        private static async Task<T> ReadBodyAsync<T>(HttpResponseData response)
+        {
+            response.Body.Position = 0;
+            return await JsonSerializer.DeserializeAsync<T>(response.Body, JsonOptions);
+        }
+
+        private static async Task<string> ReadBodyTextAsync(HttpResponseData response)
+        {
+            response.Body.Position = 0;
+            using var reader = new StreamReader(response.Body, Encoding.UTF8, leaveOpen: true);
+            return await reader.ReadToEndAsync();
+        }
+
+        private sealed record MongoContext(
+            Mock<IMongoClient> Client,
+            Mock<IMongoCollection<RatingModel>> CollectionMock);
+
+        private sealed class TestAsyncCursor<T> : IAsyncCursor<T>
+        {
+            private readonly IReadOnlyList<T> _items;
+            private bool _moved;
+
+            public TestAsyncCursor(IEnumerable<T> items)
+            {
+                _items = new List<T>(items);
+            }
+
+            public IEnumerable<T> Current => _moved ? _items : Array.Empty<T>();
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext(CancellationToken cancellationToken = default)
+            {
+                if (_moved)
+                {
+                    return false;
+                }
+
+                _moved = true;
+                return _items.Count > 0;
+            }
+
+            public Task<bool> MoveNextAsync(CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(MoveNext(cancellationToken));
+            }
+        }
+    }
+}

--- a/TestRating/TestRating.csproj
+++ b/TestRating/TestRating.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="10.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- add unit tests covering GetRating, GetAllRatings, and UpsertRating paths
- switch function DI to IMongoClient and use FindAsync so MongoDB access is mockable
- keep the existing summary tests and extend overall test coverage to all functions

## Testing
- dotnet test Rating.sln

Closes #11