### PR TITLE
Add input validation for rating submissions

### DIFF
--- a/Rating/Functions/GetRating.cs
+++ b/Rating/Functions/GetRating.cs
@@ -35,7 +35,9 @@ namespace Rating.Functions
                 if (id <= 0)
                 {
                     _logger.LogWarning("Invalid PersonId requested: {PersonId}", id);
-                    return req.CreateResponse(HttpStatusCode.BadRequest);
+                    var badRequestResponse = req.CreateResponse(HttpStatusCode.BadRequest);
+                    await badRequestResponse.WriteAsJsonAsync(new { error = "PersonId must be greater than 0" });
+                    return badRequestResponse;
                 }
 
                 var filter = Builders<Model.Rating>.Filter.Eq(rating => rating.PersonId, id);

--- a/Rating/Functions/GetRating.cs
+++ b/Rating/Functions/GetRating.cs
@@ -31,6 +31,13 @@ namespace Rating.Functions
         {
             try
             {
+                // Validate PersonId
+                if (id <= 0)
+                {
+                    _logger.LogWarning("Invalid PersonId requested: {PersonId}", id);
+                    return req.CreateResponse(HttpStatusCode.BadRequest);
+                }
+
                 var filter = Builders<Model.Rating>.Filter.Eq(rating => rating.PersonId, id);
                 using var cursor = await _ratings.FindAsync(filter);
                 var result = await cursor.ToListAsync();

--- a/Rating/Functions/UpsertRating.cs
+++ b/Rating/Functions/UpsertRating.cs
@@ -37,6 +37,16 @@ namespace Rating.Functions
                     return req.CreateResponse(HttpStatusCode.BadRequest);
                 }
 
+                // Validate input
+                var (isValid, errorMessage) = RatingValidator.Validate(rating);
+                if (!isValid)
+                {
+                    _logger.LogWarning("Invalid rating submission: {ErrorMessage}", errorMessage);
+                    var response = req.CreateResponse(HttpStatusCode.BadRequest);
+                    await response.WriteAsJsonAsync(new { error = errorMessage });
+                    return response;
+                }
+
                 var filter = Builders<Model.Rating>.Filter.Where(ex => ex.PersonId == rating.PersonId && ex.UserId == rating.UserId);
                 using var cursor = await _ratings.FindAsync(filter);
                 var exrating = (await cursor.ToListAsync()).FirstOrDefault();

--- a/Rating/Functions/UpsertRating.cs
+++ b/Rating/Functions/UpsertRating.cs
@@ -6,6 +6,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using MongoDB.Driver;
+using Rating;
 
 namespace Rating.Functions
 {
@@ -34,7 +35,10 @@ namespace Rating.Functions
             {
                 if (rating == null)
                 {
-                    return req.CreateResponse(HttpStatusCode.BadRequest);
+                    _logger.LogWarning("Invalid rating submission: request body is null.");
+                    var response = req.CreateResponse(HttpStatusCode.BadRequest);
+                    await response.WriteAsJsonAsync(new { error = "Request body is required." });
+                    return response;
                 }
 
                 // Validate input

--- a/Rating/RatingValidator.cs
+++ b/Rating/RatingValidator.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Rating.Model;
 
 namespace Rating
@@ -10,7 +8,7 @@ namespace Rating
         /// Validates a Rating object according to business rules.
         /// Returns a tuple of (isValid, errorMessage).
         /// </summary>
-        public static (bool isValid, string errorMessage) Validate(Rating rating)
+        public static (bool isValid, string errorMessage) Validate(Model.Rating rating)
         {
             if (rating == null)
             {

--- a/Rating/RatingValidator.cs
+++ b/Rating/RatingValidator.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using Rating.Model;
+
+namespace Rating
+{
+    public static class RatingValidator
+    {
+        /// <summary>
+        /// Validates a Rating object according to business rules.
+        /// Returns a tuple of (isValid, errorMessage).
+        /// </summary>
+        public static (bool isValid, string errorMessage) Validate(Rating rating)
+        {
+            if (rating == null)
+            {
+                return (false, "Rating object cannot be null");
+            }
+
+            if (string.IsNullOrWhiteSpace(rating.UserId))
+            {
+                return (false, "UserId cannot be empty or whitespace");
+            }
+
+            if (rating.PersonId <= 0)
+            {
+                return (false, "PersonId must be greater than 0");
+            }
+
+            // Rate can be 0 (deletion), but otherwise must be 1-10
+            if (rating.Rate != 0 && (rating.Rate < 1 || rating.Rate > 10))
+            {
+                return (false, "Rate must be 0 (to delete) or between 1 and 10");
+            }
+
+            return (true, null);
+        }
+    }
+}

--- a/TestRating/FunctionTests.cs
+++ b/TestRating/FunctionTests.cs
@@ -236,6 +236,115 @@ namespace TestRating
             Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
         }
 
+        [TestMethod]
+        public async Task GetRatingReturnsBadRequestWhenPersonIdIsZero()
+        {
+            var mongo = CreateMongoContext();
+            var function = new GetRating(mongo.Client.Object, Mock.Of<ILogger<GetRating>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request, 0);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("PersonId must be greater than 0", json.GetProperty("error").GetString());
+        }
+
+        [TestMethod]
+        public async Task GetRatingReturnsBadRequestWhenPersonIdIsNegative()
+        {
+            var mongo = CreateMongoContext();
+            var function = new GetRating(mongo.Client.Object, Mock.Of<ILogger<GetRating>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request, -5);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("PersonId must be greater than 0", json.GetProperty("error").GetString());
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReturnsBadRequestWhenBodyIsNullWithErrorPayload()
+        {
+            var mongo = CreateMongoContext();
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(null);
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("Request body is required.", json.GetProperty("error").GetString());
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReturnsBadRequestWhenPersonIdIsZero()
+        {
+            var invalidRating = new RatingModel { PersonId = 0, UserId = "alex", Rate = 7 };
+            var mongo = CreateMongoContext();
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(invalidRating);
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("PersonId must be greater than 0", json.GetProperty("error").GetString());
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReturnsBadRequestWhenRateIsInvalid()
+        {
+            var invalidRating = new RatingModel { PersonId = 9, UserId = "alex", Rate = 15 };
+            var mongo = CreateMongoContext();
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(invalidRating);
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("Rate must be 0 (to delete) or between 1 and 10", json.GetProperty("error").GetString());
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReturnsBadRequestWhenUserIdIsEmpty()
+        {
+            var invalidRating = new RatingModel { PersonId = 9, UserId = "", Rate = 7 };
+            var mongo = CreateMongoContext();
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(invalidRating);
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("UserId cannot be empty or whitespace", json.GetProperty("error").GetString());
+        }
+
+        [TestMethod]
+        public async Task UpsertRatingReturnsBadRequestWhenUserIdIsWhitespace()
+        {
+            var invalidRating = new RatingModel { PersonId = 9, UserId = "   ", Rate = 7 };
+            var mongo = CreateMongoContext();
+            var function = new UpsertRating(mongo.Client.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(invalidRating);
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("UserId cannot be empty or whitespace", json.GetProperty("error").GetString());
+        }
+
         private static MongoContext CreateMongoContext(IEnumerable<RatingModel> queryResults = null)
         {
             var collectionMock = new Mock<IMongoCollection<RatingModel>>();


### PR DESCRIPTION
## Summary
Enforce business rules to prevent invalid data from being stored:

- **PersonId validation:** Must be > 0
- **Rate validation:** Must be 0 (delete) or 1-10
- **UserId validation:** Must be non-empty and non-whitespace

## Implementation
- Create \RatingValidator\ class with reusable \Validate()\ method
- Apply validation in \UpsertRating\ before database operations
- Add PersonId validation in \GetRating\ endpoint
- Return 400 BadRequest with descriptive error messages
- Log validation warnings for monitoring

## Testing
- Manual testing recommended for edge cases
- Validation covers all three business rules per spec

Closes #12