### PR TITLE
Fix PR #23 review comments

### DIFF
--- a/Rating/Data/CosmosDataStore.cs
+++ b/Rating/Data/CosmosDataStore.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Azure.Cosmos;
+using Microsoft.Azure.Cosmos;
 
 namespace Rating.Data
 {
@@ -10,7 +10,7 @@ namespace Rating.Data
     /// </summary>
     public class CosmosDataStore : IDataStore
     {
-        private readonly CosmosContainer _container;
+        private readonly Container _container;
 
         public CosmosDataStore(CosmosClient cosmosClient)
         {
@@ -24,14 +24,18 @@ namespace Rating.Data
                 "SELECT * FROM c WHERE c.PersonId = @personId AND c.UserId = @userId")
                 .WithParameter("@personId", personId)
                 .WithParameter("@userId", userId);
-            
-            var iterator = _container.GetItemQueryIterator<Model.Rating>(queryDefinition);
-            
-            await foreach (var item in iterator)
+
+            using FeedIterator<Model.Rating> iterator = _container.GetItemQueryIterator<Model.Rating>(queryDefinition);
+
+            while (iterator.HasMoreResults)
             {
-                return item;
+                FeedResponse<Model.Rating> response = await iterator.ReadNextAsync();
+                foreach (var item in response)
+                {
+                    return item;
+                }
             }
-            
+
             return null;
         }
 
@@ -40,29 +44,31 @@ namespace Rating.Data
             var queryDefinition = new QueryDefinition(
                 "SELECT * FROM c WHERE c.PersonId = @personId")
                 .WithParameter("@personId", personId);
-            
-            var iterator = _container.GetItemQueryIterator<Model.Rating>(queryDefinition);
+
+            using FeedIterator<Model.Rating> iterator = _container.GetItemQueryIterator<Model.Rating>(queryDefinition);
             var results = new List<Model.Rating>();
-            
-            await foreach (var item in iterator)
+
+            while (iterator.HasMoreResults)
             {
-                results.Add(item);
+                FeedResponse<Model.Rating> response = await iterator.ReadNextAsync();
+                results.AddRange(response);
             }
-            
+
             return results;
         }
 
         public async Task<List<Model.Rating>> GetAllRatingsAsync()
         {
             var query = "SELECT * FROM c";
-            var iterator = _container.GetItemQueryIterator<Model.Rating>(query);
+            using FeedIterator<Model.Rating> iterator = _container.GetItemQueryIterator<Model.Rating>(query);
             var results = new List<Model.Rating>();
-            
-            await foreach (var item in iterator)
+
+            while (iterator.HasMoreResults)
             {
-                results.Add(item);
+                FeedResponse<Model.Rating> response = await iterator.ReadNextAsync();
+                results.AddRange(response);
             }
-            
+
             return results;
         }
 

--- a/Rating/Data/CosmosDataStore.cs
+++ b/Rating/Data/CosmosDataStore.cs
@@ -25,7 +25,13 @@ namespace Rating.Data
                 .WithParameter("@personId", personId)
                 .WithParameter("@userId", userId);
 
-            using FeedIterator<Model.Rating> iterator = _container.GetItemQueryIterator<Model.Rating>(queryDefinition);
+            using FeedIterator<Model.Rating> iterator = _container.GetItemQueryIterator<Model.Rating>(
+                queryDefinition,
+                requestOptions: new QueryRequestOptions
+                {
+                    PartitionKey = new PartitionKey(personId),
+                    MaxItemCount = 1
+                });
 
             while (iterator.HasMoreResults)
             {
@@ -45,7 +51,12 @@ namespace Rating.Data
                 "SELECT * FROM c WHERE c.PersonId = @personId")
                 .WithParameter("@personId", personId);
 
-            using FeedIterator<Model.Rating> iterator = _container.GetItemQueryIterator<Model.Rating>(queryDefinition);
+            using FeedIterator<Model.Rating> iterator = _container.GetItemQueryIterator<Model.Rating>(
+                queryDefinition,
+                requestOptions: new QueryRequestOptions
+                {
+                    PartitionKey = new PartitionKey(personId)
+                });
             var results = new List<Model.Rating>();
 
             while (iterator.HasMoreResults)

--- a/Rating/Data/MongoDataStore.cs
+++ b/Rating/Data/MongoDataStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace Rating.Data
@@ -40,7 +41,11 @@ namespace Rating.Data
 
         public async Task CreateRatingAsync(Model.Rating rating)
         {
-            rating.Id = Guid.NewGuid().ToString();
+            if (string.IsNullOrWhiteSpace(rating.Id))
+            {
+                rating.Id = ObjectId.GenerateNewId().ToString();
+            }
+
             await _collection.InsertOneAsync(rating);
         }
 

--- a/Rating/Data/MongoDataStore.cs
+++ b/Rating/Data/MongoDataStore.cs
@@ -41,11 +41,9 @@ namespace Rating.Data
 
         public async Task CreateRatingAsync(Model.Rating rating)
         {
-            if (string.IsNullOrWhiteSpace(rating.Id))
-            {
-                rating.Id = ObjectId.GenerateNewId().ToString();
-            }
-
+            rating.Id = ObjectId.TryParse(rating.Id, out var objectId)
+                ? objectId.ToString()
+                : ObjectId.GenerateNewId().ToString();
             await _collection.InsertOneAsync(rating);
         }
 

--- a/Rating/Functions/UpsertRating.cs
+++ b/Rating/Functions/UpsertRating.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -26,7 +27,19 @@ namespace Rating.Functions
         public async Task<HttpResponseData> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "rating")] HttpRequestData req)
         {
-            var rating = await req.ReadFromJsonAsync<Model.Rating>();
+            Model.Rating rating;
+
+            try
+            {
+                rating = await req.ReadFromJsonAsync<Model.Rating>();
+            }
+            catch (Exception ex) when (IsInvalidRequestPayload(ex))
+            {
+                _logger.LogWarning(ex, "Invalid rating submission: malformed JSON payload.");
+                var response = req.CreateResponse(HttpStatusCode.BadRequest);
+                await response.WriteAsJsonAsync(new { error = "Request body contains invalid JSON." });
+                return response;
+            }
 
             try
             {
@@ -78,6 +91,21 @@ namespace Rating.Functions
                 _logger.LogError(ex, "Could not update Rating Person: {PersonId} by User: {UserId}.", rating?.PersonId, rating?.UserId);
                 return req.CreateResponse(HttpStatusCode.InternalServerError);
             }
+        }
+
+        private static bool IsInvalidRequestPayload(Exception exception)
+        {
+            while (exception != null)
+            {
+                if (exception is JsonException || exception is FormatException || exception is InvalidOperationException || exception is NotSupportedException)
+                {
+                    return true;
+                }
+
+                exception = exception.InnerException;
+            }
+
+            return false;
         }
     }
 }

--- a/Rating/Model/Rating.cs
+++ b/Rating/Model/Rating.cs
@@ -7,6 +7,7 @@ namespace Rating.Model
     public class Rating
     {
         [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
         [JsonPropertyName("id")]
         public string Id { get; set; }
 

--- a/Rating/Program.cs
+++ b/Rating/Program.cs
@@ -1,20 +1,34 @@
 using System;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MongoDB.Driver;
-using Azure.Cosmos;
 using Rating;
 using Rating.Data;
 
 var mongoConnectionString = Environment.GetEnvironmentVariable(Settings.MONGO_CONNECTION_STRING);
 var cosmosConnectionString = Environment.GetEnvironmentVariable(Settings.COSMOS_CONNECTION_STRING);
+var dataStoreType = Environment.GetEnvironmentVariable(Settings.DATA_STORE_TYPE);
 
-// Default to MongoDB, but allow switching via environment variable
-var useCosmosDb = !string.IsNullOrWhiteSpace(cosmosConnectionString) && 
-                  string.Equals(Environment.GetEnvironmentVariable(Settings.DATA_STORE_TYPE), Settings.COSMOS_DATA_STORE, StringComparison.OrdinalIgnoreCase);
+var useCosmosDb = string.Equals(dataStoreType, Settings.COSMOS_DATA_STORE, StringComparison.OrdinalIgnoreCase);
 
-if (!useCosmosDb && string.IsNullOrWhiteSpace(mongoConnectionString))
+if (!string.IsNullOrWhiteSpace(dataStoreType) &&
+    !useCosmosDb &&
+    !string.Equals(dataStoreType, Settings.MONGO_DATA_STORE, StringComparison.OrdinalIgnoreCase))
+{
+    throw new InvalidOperationException(
+        $"Unsupported {Settings.DATA_STORE_TYPE} value '{dataStoreType}'. Expected '{Settings.MONGO_DATA_STORE}' or '{Settings.COSMOS_DATA_STORE}'.");
+}
+
+if (useCosmosDb)
+{
+    if (string.IsNullOrWhiteSpace(cosmosConnectionString))
+    {
+        throw new InvalidOperationException($"Missing required environment variable: {Settings.COSMOS_CONNECTION_STRING}");
+    }
+}
+else if (string.IsNullOrWhiteSpace(mongoConnectionString))
 {
     throw new InvalidOperationException($"Missing required environment variable: {Settings.MONGO_CONNECTION_STRING}");
 }

--- a/Rating/Rating.csproj
+++ b/Rating/Rating.csproj
@@ -9,7 +9,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" PrivateAssets="all" />
     <PackageReference Include="MongoDB.Driver" Version="3.8.0" />
-    <PackageReference Include="Azure.Cosmos" Version="4.0.0-preview3" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/Rating/Rating.csproj
+++ b/Rating/Rating.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" PrivateAssets="all" />
     <PackageReference Include="MongoDB.Driver" Version="3.8.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
+    <!-- Microsoft.Azure.Cosmos build targets require an explicit Newtonsoft.Json reference. -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/TestRating/FunctionTests.cs
+++ b/TestRating/FunctionTests.cs
@@ -114,7 +114,7 @@ namespace TestRating
         {
             var store = CreateDataStoreContext();
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(null);
+            var request = CreateRequest(null, "PUT");
 
             var response = await function.Run(request);
 
@@ -128,7 +128,7 @@ namespace TestRating
             var store = CreateDataStoreContext(Array.Empty<RatingModel>());
 
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(newRating);
+            var request = CreateRequest(newRating, "PUT");
 
             var response = await function.Run(request);
             var body = await ReadBodyAsync<RatingModel>(response);
@@ -148,7 +148,7 @@ namespace TestRating
             var store = CreateDataStoreContext(new[] { existing });
 
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(update);
+            var request = CreateRequest(update, "PUT");
 
             var response = await function.Run(request);
             var bodyText = await ReadBodyTextAsync(response);
@@ -165,7 +165,7 @@ namespace TestRating
             var store = CreateDataStoreContext(new[] { existing });
 
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(update);
+            var request = CreateRequest(update, "PUT");
 
             var response = await function.Run(request);
             var body = await ReadBodyAsync<RatingModel>(response);
@@ -186,7 +186,7 @@ namespace TestRating
                 .ThrowsAsync(new InvalidOperationException("boom"));
 
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(newRating);
+            var request = CreateRequest(newRating, "PUT");
 
             var response = await function.Run(request);
 
@@ -228,7 +228,7 @@ namespace TestRating
         {
             var store = CreateDataStoreContext();
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(null);
+            var request = CreateRequest(null, "PUT");
 
             var response = await function.Run(request);
             var bodyText = await ReadBodyTextAsync(response);
@@ -244,7 +244,7 @@ namespace TestRating
             var invalidRating = new RatingModel { PersonId = 0, UserId = "alex", Rate = 7 };
             var store = CreateDataStoreContext();
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(invalidRating);
+            var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
             var bodyText = await ReadBodyTextAsync(response);
@@ -260,7 +260,7 @@ namespace TestRating
             var invalidRating = new RatingModel { PersonId = 9, UserId = "alex", Rate = 15 };
             var store = CreateDataStoreContext();
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(invalidRating);
+            var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
             var bodyText = await ReadBodyTextAsync(response);
@@ -276,7 +276,7 @@ namespace TestRating
             var invalidRating = new RatingModel { PersonId = 9, UserId = "", Rate = 7 };
             var store = CreateDataStoreContext();
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(invalidRating);
+            var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
             var bodyText = await ReadBodyTextAsync(response);
@@ -292,7 +292,7 @@ namespace TestRating
             var invalidRating = new RatingModel { PersonId = 9, UserId = "   ", Rate = 7 };
             var store = CreateDataStoreContext();
             var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
-            var request = CreateRequest(invalidRating);
+            var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
             var bodyText = await ReadBodyTextAsync(response);
@@ -302,17 +302,32 @@ namespace TestRating
             Assert.AreEqual("UserId cannot be empty or whitespace", json.GetProperty("error").GetString());
         }
 
-        private static HttpRequestData CreateRequest(object body)
+        [TestMethod]
+        public async Task UpsertRatingReturnsBadRequestWhenJsonIsMalformed()
+        {
+            var store = CreateDataStoreContext();
+            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var request = CreateRequest(null, "PUT", "{");
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual("Request body contains invalid JSON.", json.GetProperty("error").GetString());
+        }
+
+        private static HttpRequestData CreateRequest(object body, string method = "GET", string rawBody = null)
         {
             var context = CreateFunctionContext();
             var response = CreateResponse(context);
             var requestMock = new Mock<HttpRequestData>(context);
-            requestMock.SetupGet(x => x.Body).Returns(CreateBodyStream(body));
+            requestMock.SetupGet(x => x.Body).Returns(CreateBodyStream(body, rawBody));
             requestMock.SetupGet(x => x.Headers).Returns(new HttpHeadersCollection());
             requestMock.SetupGet(x => x.Cookies).Returns(Array.Empty<IHttpCookie>());
             requestMock.SetupGet(x => x.Url).Returns(new Uri("https://localhost/api/rating"));
             requestMock.SetupGet(x => x.Identities).Returns(Array.Empty<ClaimsIdentity>());
-            requestMock.SetupGet(x => x.Method).Returns("GET");
+            requestMock.SetupGet(x => x.Method).Returns(method);
             requestMock.Setup(x => x.CreateResponse()).Returns(response);
 
             return requestMock.Object;
@@ -343,9 +358,9 @@ namespace TestRating
             return contextMock.Object;
         }
 
-        private static MemoryStream CreateBodyStream(object body)
+        private static MemoryStream CreateBodyStream(object body, string rawBody = null)
         {
-            var json = JsonSerializer.Serialize(body);
+            var json = rawBody ?? JsonSerializer.Serialize(body);
             return new MemoryStream(Encoding.UTF8.GetBytes(json));
         }
 


### PR DESCRIPTION
## Summary
- address the review comments blocking the dev-to-master merge
- preserve MongoDB ObjectId compatibility while keeping Cosmos support
- switch to the stable Cosmos SDK and improve request/config validation

## Changes
- restore Mongo `_id` ObjectId representation on `Rating.Id`
- generate ObjectId-compatible IDs for new Mongo records
- validate `DATA_STORE_TYPE` explicitly and require the matching connection string
- replace preview `Azure.Cosmos` with stable `Microsoft.Azure.Cosmos`
- return a 400 response for malformed JSON payloads
- update tests for PUT requests and malformed JSON handling