### PR TITLE
Fix Azure Function deploy target

### DIFF
--- a/.github/workflows/master_rating.yml
+++ b/.github/workflows/master_rating.yml
@@ -1,7 +1,7 @@
 # Docs for the Azure Web Apps Deploy action: https://github.com/azure/functions-action
 # More GitHub Actions for Azure: https://github.com/Azure/actions
 
-name: Build and deploy dotnet core app to Azure Function App - PeopleRating
+name: Build and deploy dotnet core app to Azure Function App - rating
 
 on:
   push:
@@ -38,7 +38,7 @@ jobs:
       uses: Azure/functions-action@v1
       id: fa
       with:
-        app-name: 'PeopleRating'
+        app-name: 'rating'
         slot-name: 'production'
         package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/publish'
         publish-profile: ${{ secrets.AzureAppService_PublishProfile_065d36bc99194ba3a5c1240f368fa47d }}


### PR DESCRIPTION
## Summary
- point the deploy workflow at the current Azure Function App name: ating`n- rename the workflow file and workflow display name to match the active Function App
- keep the existing publish profile secret reference unchanged

Fixes #22