### PR TITLE
Switch Azure deploy to OIDC

### DIFF
--- a/.github/workflows/master_rating.yml
+++ b/.github/workflows/master_rating.yml
@@ -9,10 +9,6 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
-
 env:
   AZURE_FUNCTIONAPP_NAME: 'rating'
   AZURE_FUNCTIONAPP_PACKAGE_PATH: './Rating'
@@ -21,6 +17,9 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
     - name: 'Checkout GitHub Action'
       uses: actions/checkout@v4
@@ -40,7 +39,7 @@ jobs:
         popd
 
     - name: 'Log in to Azure'
-      uses: azure/login@v2
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/master_rating.yml
+++ b/.github/workflows/master_rating.yml
@@ -9,6 +9,10 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   AZURE_FUNCTIONAPP_NAME: 'rating'
   AZURE_FUNCTIONAPP_PACKAGE_PATH: './Rating'
@@ -35,6 +39,13 @@ jobs:
         dotnet publish --configuration Release --output ./publish
         popd
 
+    - name: 'Log in to Azure'
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
     - name: 'Run Azure Functions Action'
       uses: Azure/functions-action@v1
       id: fa
@@ -42,5 +53,4 @@ jobs:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
         slot-name: 'production'
         package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/publish'
-        publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}
   


### PR DESCRIPTION
## Summary
- switch the Azure Functions deployment workflow from publish-profile auth to OIDC via `azure/login`
- grant the workflow `id-token: write` permission required for GitHub OIDC federation
- keep the Linux runner, build, test, and publish steps unchanged

## Required GitHub configuration
Configure these repository secrets before merging or rerunning:
- `AZURE_CLIENT_ID`
- `AZURE_TENANT_ID`
- `AZURE_SUBSCRIPTION_ID`

Also create the Azure federated credential for this repository and branch/workflow scope so `azure/login` can exchange the GitHub OIDC token.

Refs #22