### PR TITLE
Validate B2C JWT on write endpoint

### DIFF
--- a/Rating/Auth/AccessTokenValidator.cs
+++ b/Rating/Auth/AccessTokenValidator.cs
@@ -70,6 +70,14 @@ namespace Rating.Auth
                 try
                 {
                     configuration = await _configurationManager.GetConfigurationAsync(cancellationToken);
+                }
+                catch (Exception)
+                {
+                    return TokenValidationOutcome.ServerError("Unable to load authentication configuration.");
+                }
+
+                try
+                {
                     return TokenValidationOutcome.Success(ValidateToken(accessToken, configuration));
                 }
                 catch (SecurityTokenException)

--- a/Rating/Auth/AccessTokenValidator.cs
+++ b/Rating/Auth/AccessTokenValidator.cs
@@ -1,0 +1,153 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using WorkerHttpRequestData = Microsoft.Azure.Functions.Worker.Http.HttpRequestData;
+
+namespace Rating.Auth
+{
+    public sealed class AccessTokenValidator : IAccessTokenValidator
+    {
+        private readonly IConfigurationManager<OpenIdConnectConfiguration> _configurationManager;
+        private readonly JwtSecurityTokenHandler _tokenHandler = new();
+        private readonly B2CAuthenticationOptions _options;
+
+        public AccessTokenValidator(string authority, string audience)
+            : this(
+                new B2CAuthenticationOptions
+                {
+                    Authority = NormalizeAuthority(authority),
+                    Audience = audience?.Trim()
+                },
+                CreateConfigurationManager(authority))
+        {
+        }
+
+        public AccessTokenValidator(
+            B2CAuthenticationOptions options,
+            IConfigurationManager<OpenIdConnectConfiguration> configurationManager)
+        {
+            _options = options;
+            _configurationManager = configurationManager;
+        }
+
+        public async Task<TokenValidationOutcome> ValidateAsync(WorkerHttpRequestData request, CancellationToken cancellationToken = default)
+        {
+            if (!_options.IsConfigured)
+            {
+                return TokenValidationOutcome.ServerError("Authentication is not configured.");
+            }
+
+            if (!TryGetBearerToken(request, out var accessToken))
+            {
+                return TokenValidationOutcome.Unauthorized("A valid Bearer token is required.");
+            }
+
+            OpenIdConnectConfiguration configuration;
+            try
+            {
+                configuration = await _configurationManager.GetConfigurationAsync(cancellationToken);
+            }
+            catch (Exception)
+            {
+                return TokenValidationOutcome.ServerError("Unable to load authentication configuration.");
+            }
+
+            try
+            {
+                return TokenValidationOutcome.Success(ValidateToken(accessToken, configuration));
+            }
+            catch (SecurityTokenSignatureKeyNotFoundException)
+            {
+                _configurationManager.RequestRefresh();
+                try
+                {
+                    configuration = await _configurationManager.GetConfigurationAsync(cancellationToken);
+                    return TokenValidationOutcome.Success(ValidateToken(accessToken, configuration));
+                }
+                catch (SecurityTokenException)
+                {
+                    return TokenValidationOutcome.Unauthorized("Bearer token is invalid.");
+                }
+                catch (ArgumentException)
+                {
+                    return TokenValidationOutcome.Unauthorized("Bearer token is invalid.");
+                }
+            }
+            catch (SecurityTokenException)
+            {
+                return TokenValidationOutcome.Unauthorized("Bearer token is invalid.");
+            }
+            catch (ArgumentException)
+            {
+                return TokenValidationOutcome.Unauthorized("Bearer token is invalid.");
+            }
+        }
+
+        private ClaimsPrincipal ValidateToken(string accessToken, OpenIdConnectConfiguration configuration)
+        {
+            var validationParameters = new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKeys = configuration.SigningKeys,
+                ValidateIssuer = true,
+                ValidIssuers = new[]
+                {
+                    configuration.Issuer,
+                    _options.Authority
+                }.Where(value => !string.IsNullOrWhiteSpace(value)),
+                ValidateAudience = true,
+                ValidAudience = _options.Audience,
+                ValidateLifetime = true,
+                RequireExpirationTime = true,
+                RequireSignedTokens = true,
+                ClockSkew = TimeSpan.FromMinutes(1)
+            };
+
+            return _tokenHandler.ValidateToken(accessToken, validationParameters, out _);
+        }
+
+        private static bool TryGetBearerToken(WorkerHttpRequestData request, out string accessToken)
+        {
+            accessToken = null;
+
+            if (!request.Headers.TryGetValues("Authorization", out var authorizationHeaders))
+            {
+                return false;
+            }
+
+            var authorizationHeader = authorizationHeaders.FirstOrDefault();
+            if (!AuthenticationHeaderValue.TryParse(authorizationHeader, out var headerValue) ||
+                !string.Equals(headerValue.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(headerValue.Parameter))
+            {
+                return false;
+            }
+
+            accessToken = headerValue.Parameter;
+            return true;
+        }
+
+        private static IConfigurationManager<OpenIdConnectConfiguration> CreateConfigurationManager(string authority)
+        {
+            var normalizedAuthority = NormalizeAuthority(authority) ?? "https://invalid.local";
+            var metadataAddress = $"{normalizedAuthority}/.well-known/openid-configuration";
+            return new ConfigurationManager<OpenIdConnectConfiguration>(
+                metadataAddress,
+                new OpenIdConnectConfigurationRetriever(),
+                new HttpDocumentRetriever { RequireHttps = true });
+        }
+
+        private static string NormalizeAuthority(string authority)
+        {
+            return authority?.Trim().TrimEnd('/');
+        }
+    }
+}

--- a/Rating/Auth/B2CAuthenticationOptions.cs
+++ b/Rating/Auth/B2CAuthenticationOptions.cs
@@ -1,0 +1,13 @@
+namespace Rating.Auth
+{
+    public sealed class B2CAuthenticationOptions
+    {
+        public string Authority { get; init; }
+
+        public string Audience { get; init; }
+
+        public bool IsConfigured =>
+            !string.IsNullOrWhiteSpace(Authority) &&
+            !string.IsNullOrWhiteSpace(Audience);
+    }
+}

--- a/Rating/Auth/IAccessTokenValidator.cs
+++ b/Rating/Auth/IAccessTokenValidator.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Functions.Worker.Http;
+
+namespace Rating.Auth
+{
+    public interface IAccessTokenValidator
+    {
+        Task<TokenValidationOutcome> ValidateAsync(HttpRequestData request, CancellationToken cancellationToken = default);
+    }
+}

--- a/Rating/Auth/TokenValidationOutcome.cs
+++ b/Rating/Auth/TokenValidationOutcome.cs
@@ -1,0 +1,21 @@
+using System.Net;
+using System.Security.Claims;
+
+namespace Rating.Auth
+{
+    public sealed record TokenValidationOutcome(
+        bool IsAuthenticated,
+        HttpStatusCode StatusCode,
+        string ErrorMessage,
+        ClaimsPrincipal Principal = null)
+    {
+        public static TokenValidationOutcome Success(ClaimsPrincipal principal) =>
+            new(true, HttpStatusCode.OK, null, principal);
+
+        public static TokenValidationOutcome Unauthorized(string errorMessage) =>
+            new(false, HttpStatusCode.Unauthorized, errorMessage);
+
+        public static TokenValidationOutcome ServerError(string errorMessage) =>
+            new(false, HttpStatusCode.InternalServerError, errorMessage);
+    }
+}

--- a/Rating/Constants.cs
+++ b/Rating/Constants.cs
@@ -1,10 +1,12 @@
-﻿namespace Rating
+namespace Rating
 {
     public class Settings
     {        
         public const string MONGO_CONNECTION_STRING = "MongoDBAtlasConnectionString";
         public const string COSMOS_CONNECTION_STRING = "CosmosDBConnectionString";
         public const string DATA_STORE_TYPE = "DATA_STORE_TYPE";
+        public const string B2C_AUTHORITY = "B2C_AUTHORITY";
+        public const string B2C_AUDIENCE = "B2C_AUDIENCE";
 
         public const string DATABASE_NAME = "People";
         public const string COLLECTION_NAME = "rating";

--- a/Rating/Functions/UpsertRating.cs
+++ b/Rating/Functions/UpsertRating.cs
@@ -6,28 +6,40 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Rating;
+using Rating.Auth;
 using Rating.Data;
 
 namespace Rating.Functions
 {
     public class UpsertRating
     {
+        private readonly IAccessTokenValidator _accessTokenValidator;
         private readonly IDataStore _dataStore;
         private readonly ILogger<UpsertRating> _logger;
 
         public UpsertRating(
             IDataStore dataStore,
-            ILogger<UpsertRating> logger)
+            ILogger<UpsertRating> logger,
+            IAccessTokenValidator accessTokenValidator)
         {
             _dataStore = dataStore;
             _logger = logger;
+            _accessTokenValidator = accessTokenValidator;
         }
 
         [Function(nameof(UpsertRating))]
         public async Task<HttpResponseData> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "rating")] HttpRequestData req)
         {
-            Model.Rating rating;
+            var tokenValidation = await _accessTokenValidator.ValidateAsync(req);
+            if (!tokenValidation.IsAuthenticated)
+            {
+                var unauthorizedResponse = req.CreateResponse(tokenValidation.StatusCode);
+                await unauthorizedResponse.WriteAsJsonAsync(new { error = tokenValidation.ErrorMessage });
+                return unauthorizedResponse;
+            }
+
+            Model.Rating rating = null;
 
             try
             {

--- a/Rating/Functions/UpsertRating.cs
+++ b/Rating/Functions/UpsertRating.cs
@@ -34,9 +34,9 @@ namespace Rating.Functions
             var tokenValidation = await _accessTokenValidator.ValidateAsync(req);
             if (!tokenValidation.IsAuthenticated)
             {
-                var unauthorizedResponse = req.CreateResponse(tokenValidation.StatusCode);
-                await unauthorizedResponse.WriteAsJsonAsync(new { error = tokenValidation.ErrorMessage });
-                return unauthorizedResponse;
+                var authFailureResponse = req.CreateResponse(tokenValidation.StatusCode);
+                await authFailureResponse.WriteAsJsonAsync(new { error = tokenValidation.ErrorMessage });
+                return authFailureResponse;
             }
 
             Model.Rating rating = null;

--- a/Rating/Program.cs
+++ b/Rating/Program.cs
@@ -4,12 +4,15 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MongoDB.Driver;
+using Rating.Auth;
 using Rating;
 using Rating.Data;
 
 var mongoConnectionString = Environment.GetEnvironmentVariable(Settings.MONGO_CONNECTION_STRING);
 var cosmosConnectionString = Environment.GetEnvironmentVariable(Settings.COSMOS_CONNECTION_STRING);
 var dataStoreType = Environment.GetEnvironmentVariable(Settings.DATA_STORE_TYPE);
+var b2cAuthority = Environment.GetEnvironmentVariable(Settings.B2C_AUTHORITY);
+var b2cAudience = Environment.GetEnvironmentVariable(Settings.B2C_AUDIENCE);
 
 var useCosmosDb = string.Equals(dataStoreType, Settings.COSMOS_DATA_STORE, StringComparison.OrdinalIgnoreCase);
 
@@ -37,6 +40,10 @@ var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices(services =>
     {
+        services.AddSingleton<IAccessTokenValidator>(_ => new AccessTokenValidator(
+            b2cAuthority,
+            b2cAudience));
+
         if (useCosmosDb)
         {
             services.AddSingleton(_ => new CosmosClient(cosmosConnectionString));

--- a/Rating/Rating.csproj
+++ b/Rating/Rating.csproj
@@ -8,10 +8,12 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.13.1" />
     <PackageReference Include="MongoDB.Driver" Version="3.8.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.59.0" />
     <!-- Microsoft.Azure.Cosmos build targets require an explicit Newtonsoft.Json reference. -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/TestRating/AccessTokenValidatorTests.cs
+++ b/TestRating/AccessTokenValidatorTests.cs
@@ -64,6 +64,28 @@ namespace TestRating
         }
 
         [TestMethod]
+        public async Task ValidateAsyncReturnsServerErrorWhenRefreshConfigurationLoadFails()
+        {
+            var initialConfiguration = CreateConfiguration();
+            var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("FEDCBA9876543210FEDCBA9876543210"));
+            var token = CreateToken(initialConfiguration.Issuer, "rating-api", signingKey, new Claim("sub", "user-123"));
+            var validator = new AccessTokenValidator(
+                new B2CAuthenticationOptions
+                {
+                    Authority = initialConfiguration.Issuer.TrimEnd('/'),
+                    Audience = "rating-api"
+                },
+                new RefreshFailingConfigurationManager(initialConfiguration, new InvalidOperationException("network failure")));
+            var request = CreateRequest($"Bearer {token}");
+
+            var outcome = await validator.ValidateAsync(request);
+
+            Assert.IsFalse(outcome.IsAuthenticated);
+            Assert.AreEqual(HttpStatusCode.InternalServerError, outcome.StatusCode);
+            Assert.AreEqual("Unable to load authentication configuration.", outcome.ErrorMessage);
+        }
+
+        [TestMethod]
         public async Task ValidateAsyncReturnsPrincipalWhenTokenIsValid()
         {
             var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("0123456789ABCDEF0123456789ABCDEF"));
@@ -167,6 +189,34 @@ namespace TestRating
 
             public void RequestRefresh()
             {
+            }
+        }
+
+        private sealed class RefreshFailingConfigurationManager : IConfigurationManager<OpenIdConnectConfiguration>
+        {
+            private readonly OpenIdConnectConfiguration _configuration;
+            private readonly Exception _refreshException;
+            private bool _wasRefreshed;
+
+            public RefreshFailingConfigurationManager(OpenIdConnectConfiguration configuration, Exception refreshException)
+            {
+                _configuration = configuration;
+                _refreshException = refreshException;
+            }
+
+            public Task<OpenIdConnectConfiguration> GetConfigurationAsync(CancellationToken cancel)
+            {
+                if (_wasRefreshed)
+                {
+                    throw _refreshException;
+                }
+
+                return Task.FromResult(_configuration);
+            }
+
+            public void RequestRefresh()
+            {
+                _wasRefreshed = true;
             }
         }
     }

--- a/TestRating/AccessTokenValidatorTests.cs
+++ b/TestRating/AccessTokenValidatorTests.cs
@@ -1,0 +1,173 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Serialization;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Rating.Auth;
+using WorkerHttpRequestData = Microsoft.Azure.Functions.Worker.Http.HttpRequestData;
+
+namespace TestRating
+{
+    [TestClass]
+    public class AccessTokenValidatorTests
+    {
+        [TestMethod]
+        public async Task ValidateAsyncReturnsUnauthorizedWhenAuthorizationHeaderIsMissing()
+        {
+            var validator = CreateValidator(CreateConfiguration());
+            var request = CreateRequest();
+
+            var outcome = await validator.ValidateAsync(request);
+
+            Assert.IsFalse(outcome.IsAuthenticated);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, outcome.StatusCode);
+            Assert.AreEqual("A valid Bearer token is required.", outcome.ErrorMessage);
+        }
+
+        [TestMethod]
+        public async Task ValidateAsyncReturnsServerErrorWhenB2CSettingsAreMissing()
+        {
+            var validator = new AccessTokenValidator(
+                new B2CAuthenticationOptions(),
+                new StaticConfigurationManager(CreateConfiguration()));
+            var request = CreateRequest("Bearer token");
+
+            var outcome = await validator.ValidateAsync(request);
+
+            Assert.IsFalse(outcome.IsAuthenticated);
+            Assert.AreEqual(HttpStatusCode.InternalServerError, outcome.StatusCode);
+            Assert.AreEqual("Authentication is not configured.", outcome.ErrorMessage);
+        }
+
+        [TestMethod]
+        public async Task ValidateAsyncReturnsUnauthorizedWhenTokenIsInvalid()
+        {
+            var validator = CreateValidator(CreateConfiguration());
+            var request = CreateRequest("Bearer not-a-jwt");
+
+            var outcome = await validator.ValidateAsync(request);
+
+            Assert.IsFalse(outcome.IsAuthenticated);
+            Assert.AreEqual(HttpStatusCode.Unauthorized, outcome.StatusCode);
+            Assert.AreEqual("Bearer token is invalid.", outcome.ErrorMessage);
+        }
+
+        [TestMethod]
+        public async Task ValidateAsyncReturnsPrincipalWhenTokenIsValid()
+        {
+            var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes("0123456789ABCDEF0123456789ABCDEF"));
+            var configuration = CreateConfiguration(signingKey);
+            var validator = CreateValidator(configuration);
+            var token = CreateToken(configuration.Issuer, "rating-api", signingKey, new Claim("sub", "user-123"));
+            var request = CreateRequest($"Bearer {token}");
+
+            var outcome = await validator.ValidateAsync(request);
+            var subject = outcome.Principal.FindFirst("sub")?.Value ??
+                outcome.Principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            Assert.IsTrue(outcome.IsAuthenticated);
+            Assert.AreEqual(HttpStatusCode.OK, outcome.StatusCode);
+            Assert.IsNotNull(outcome.Principal);
+            Assert.AreEqual("user-123", subject);
+        }
+
+        private static AccessTokenValidator CreateValidator(OpenIdConnectConfiguration configuration)
+        {
+            return new AccessTokenValidator(
+                new B2CAuthenticationOptions
+                {
+                    Authority = configuration.Issuer.TrimEnd('/'),
+                    Audience = "rating-api"
+                },
+                new StaticConfigurationManager(configuration));
+        }
+
+        private static OpenIdConnectConfiguration CreateConfiguration(SecurityKey signingKey = null)
+        {
+            var configuration = new OpenIdConnectConfiguration
+            {
+                Issuer = "https://example.b2clogin.com/example.onmicrosoft.com/B2C_1_signin/v2.0/"
+            };
+
+            configuration.SigningKeys.Add(signingKey ?? new SymmetricSecurityKey(Encoding.UTF8.GetBytes("0123456789ABCDEF0123456789ABCDEF")));
+            return configuration;
+        }
+
+        private static string CreateToken(string issuer, string audience, SecurityKey signingKey, params Claim[] claims)
+        {
+            var token = new JwtSecurityToken(
+                issuer: issuer,
+                audience: audience,
+                claims: claims,
+                expires: DateTime.UtcNow.AddMinutes(5),
+                signingCredentials: new SigningCredentials(signingKey, SecurityAlgorithms.HmacSha256));
+
+            return new JwtSecurityTokenHandler().WriteToken(token);
+        }
+
+        private static WorkerHttpRequestData CreateRequest(string authorizationHeader = null)
+        {
+            var context = CreateFunctionContext();
+            var requestMock = new Mock<WorkerHttpRequestData>(context);
+            var headers = new HttpHeadersCollection();
+
+            if (!string.IsNullOrWhiteSpace(authorizationHeader))
+            {
+                headers.Add("Authorization", authorizationHeader);
+            }
+
+            requestMock.SetupGet(x => x.Body).Returns(new System.IO.MemoryStream(Array.Empty<byte>()));
+            requestMock.SetupGet(x => x.Headers).Returns(headers);
+            requestMock.SetupGet(x => x.Cookies).Returns(Array.Empty<IHttpCookie>());
+            requestMock.SetupGet(x => x.Url).Returns(new Uri("https://localhost/api/rating"));
+            requestMock.SetupGet(x => x.Identities).Returns(Array.Empty<ClaimsIdentity>());
+            requestMock.SetupGet(x => x.Method).Returns("PUT");
+
+            return requestMock.Object;
+        }
+
+        private static FunctionContext CreateFunctionContext()
+        {
+            var services = new ServiceCollection();
+            services
+                .AddOptions<WorkerOptions>()
+                .Configure(options => options.Serializer = new JsonObjectSerializer());
+            var serviceProvider = services.BuildServiceProvider();
+
+            var contextMock = new Mock<FunctionContext>();
+            contextMock.SetupProperty(x => x.InstanceServices, serviceProvider);
+
+            return contextMock.Object;
+        }
+
+        private sealed class StaticConfigurationManager : IConfigurationManager<OpenIdConnectConfiguration>
+        {
+            private readonly OpenIdConnectConfiguration _configuration;
+
+            public StaticConfigurationManager(OpenIdConnectConfiguration configuration)
+            {
+                _configuration = configuration;
+            }
+
+            public Task<OpenIdConnectConfiguration> GetConfigurationAsync(CancellationToken cancel)
+            {
+                return Task.FromResult(_configuration);
+            }
+
+            public void RequestRefresh()
+            {
+            }
+        }
+    }
+}

--- a/TestRating/FunctionTests.cs
+++ b/TestRating/FunctionTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Rating;
+using Rating.Auth;
 using Rating.Data;
 using Rating.Functions;
 using Rating.Model;
@@ -113,7 +114,7 @@ namespace TestRating
         public async Task UpsertRatingReturnsBadRequestWhenBodyIsNull()
         {
             var store = CreateDataStoreContext();
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(null, "PUT");
 
             var response = await function.Run(request);
@@ -127,7 +128,7 @@ namespace TestRating
             var newRating = new RatingModel { PersonId = 9, UserId = "alex", Rate = 7 };
             var store = CreateDataStoreContext(Array.Empty<RatingModel>());
 
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(newRating, "PUT");
 
             var response = await function.Run(request);
@@ -147,7 +148,7 @@ namespace TestRating
             var update = new RatingModel { PersonId = 9, UserId = "alex", Rate = 0 };
             var store = CreateDataStoreContext(new[] { existing });
 
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(update, "PUT");
 
             var response = await function.Run(request);
@@ -164,7 +165,7 @@ namespace TestRating
             var update = new RatingModel { PersonId = 9, UserId = "alex", Rate = 8 };
             var store = CreateDataStoreContext(new[] { existing });
 
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(update, "PUT");
 
             var response = await function.Run(request);
@@ -185,7 +186,7 @@ namespace TestRating
                 .Setup(x => x.CreateRatingAsync(It.IsAny<RatingModel>()))
                 .ThrowsAsync(new InvalidOperationException("boom"));
 
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(newRating, "PUT");
 
             var response = await function.Run(request);
@@ -227,7 +228,7 @@ namespace TestRating
         public async Task UpsertRatingReturnsBadRequestWhenBodyIsNullWithErrorPayload()
         {
             var store = CreateDataStoreContext();
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(null, "PUT");
 
             var response = await function.Run(request);
@@ -243,7 +244,7 @@ namespace TestRating
         {
             var invalidRating = new RatingModel { PersonId = 0, UserId = "alex", Rate = 7 };
             var store = CreateDataStoreContext();
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
@@ -259,7 +260,7 @@ namespace TestRating
         {
             var invalidRating = new RatingModel { PersonId = 9, UserId = "alex", Rate = 15 };
             var store = CreateDataStoreContext();
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
@@ -275,7 +276,7 @@ namespace TestRating
         {
             var invalidRating = new RatingModel { PersonId = 9, UserId = "", Rate = 7 };
             var store = CreateDataStoreContext();
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
@@ -291,7 +292,7 @@ namespace TestRating
         {
             var invalidRating = new RatingModel { PersonId = 9, UserId = "   ", Rate = 7 };
             var store = CreateDataStoreContext();
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(invalidRating, "PUT");
 
             var response = await function.Run(request);
@@ -306,7 +307,7 @@ namespace TestRating
         public async Task UpsertRatingReturnsBadRequestWhenJsonIsMalformed()
         {
             var store = CreateDataStoreContext();
-            var function = new UpsertRating(store.StoreMock.Object, Mock.Of<ILogger<UpsertRating>>());
+            var function = CreateUpsertRating(store.StoreMock.Object);
             var request = CreateRequest(null, "PUT", "{");
 
             var response = await function.Run(request);
@@ -317,13 +318,41 @@ namespace TestRating
             Assert.AreEqual("Request body contains invalid JSON.", json.GetProperty("error").GetString());
         }
 
-        private static HttpRequestData CreateRequest(object body, string method = "GET", string rawBody = null)
+        [TestMethod]
+        public async Task UpsertRatingReturnsUnauthorizedWhenTokenValidationFails()
+        {
+            var store = CreateDataStoreContext();
+            var function = CreateUpsertRating(
+                store.StoreMock.Object,
+                TokenValidationOutcome.Unauthorized("A valid Bearer token is required."));
+            var request = CreateRequest(new RatingModel { PersonId = 9, UserId = "alex", Rate = 7 }, "PUT");
+
+            var response = await function.Run(request);
+            var bodyText = await ReadBodyTextAsync(response);
+            var json = JsonDocument.Parse(bodyText).RootElement;
+
+            Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+            Assert.AreEqual("A valid Bearer token is required.", json.GetProperty("error").GetString());
+            store.StoreMock.Verify(x => x.FindRatingAsync(It.IsAny<int>(), It.IsAny<string>()), Times.Never);
+            store.StoreMock.Verify(x => x.CreateRatingAsync(It.IsAny<RatingModel>()), Times.Never);
+            store.StoreMock.Verify(x => x.UpdateRatingAsync(It.IsAny<RatingModel>()), Times.Never);
+            store.StoreMock.Verify(x => x.DeleteRatingAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+        }
+
+        private static HttpRequestData CreateRequest(object body, string method = "GET", string rawBody = null, string authorizationHeader = null)
         {
             var context = CreateFunctionContext();
             var response = CreateResponse(context);
             var requestMock = new Mock<HttpRequestData>(context);
+            var headers = new HttpHeadersCollection();
+
+            if (!string.IsNullOrWhiteSpace(authorizationHeader))
+            {
+                headers.Add("Authorization", authorizationHeader);
+            }
+
             requestMock.SetupGet(x => x.Body).Returns(CreateBodyStream(body, rawBody));
-            requestMock.SetupGet(x => x.Headers).Returns(new HttpHeadersCollection());
+            requestMock.SetupGet(x => x.Headers).Returns(headers);
             requestMock.SetupGet(x => x.Cookies).Returns(Array.Empty<IHttpCookie>());
             requestMock.SetupGet(x => x.Url).Returns(new Uri("https://localhost/api/rating"));
             requestMock.SetupGet(x => x.Identities).Returns(Array.Empty<ClaimsIdentity>());
@@ -342,6 +371,12 @@ namespace TestRating
             responseMock.SetupGet(x => x.Cookies).Returns(Mock.Of<HttpCookies>());
 
             return responseMock.Object;
+        }
+
+        private static UpsertRating CreateUpsertRating(IDataStore dataStore, TokenValidationOutcome outcome = null)
+        {
+            var tokenValidationOutcome = outcome ?? TokenValidationOutcome.Success(new ClaimsPrincipal(new ClaimsIdentity("Test")));
+            return new UpsertRating(dataStore, Mock.Of<ILogger<UpsertRating>>(), new StubAccessTokenValidator(tokenValidationOutcome));
         }
 
         private static FunctionContext CreateFunctionContext()
@@ -379,6 +414,21 @@ namespace TestRating
 
         private sealed record DataStoreContext(
             Mock<IDataStore> StoreMock);
+
+        private sealed class StubAccessTokenValidator : IAccessTokenValidator
+        {
+            private readonly TokenValidationOutcome _outcome;
+
+            public StubAccessTokenValidator(TokenValidationOutcome outcome)
+            {
+                _outcome = outcome;
+            }
+
+            public Task<TokenValidationOutcome> ValidateAsync(HttpRequestData request, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(_outcome);
+            }
+        }
 
         private static DataStoreContext CreateDataStoreContext(IEnumerable<RatingModel> queryResults = null)
         {


### PR DESCRIPTION
## Summary
- validate Azure AD B2C bearer tokens before allowing UpsertRating writes
- keep GetRating and GetAllRatings public
- add auth-focused tests for token validation and unauthorized write attempts

## Configuration
- requires the Azure Function app to set B2C_AUTHORITY and B2C_AUDIENCE

Closes #16