### PR TITLE
Add CORS support to rating endpoints

### DIFF
--- a/Rating/Functions/GetAllRatings.cs
+++ b/Rating/Functions/GetAllRatings.cs
@@ -27,10 +27,21 @@ namespace Rating.Functions
         public async Task<HttpResponseData> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "ratings")] HttpRequestData req)
         {
+            // Handle CORS preflight requests
+            if (req.Method == "OPTIONS")
+            {
+                var corsResponse = req.CreateResponse(System.Net.HttpStatusCode.OK);
+                corsResponse.Headers.Add("Access-Control-Allow-Origin", "*");
+                corsResponse.Headers.Add("Access-Control-Allow-Methods", "GET, OPTIONS");
+                corsResponse.Headers.Add("Access-Control-Allow-Headers", "Content-Type, Authorization");
+                return corsResponse;
+            }
+            
             try
             {
                 var result = await _dataStore.GetAllRatingsAsync();
                 var response = req.CreateResponse(HttpStatusCode.OK);
+                response.Headers.Add("Access-Control-Allow-Origin", "*");
                 await response.WriteAsJsonAsync(RatingSummaries.CreateAll(result));
                 return response;
             }

--- a/Rating/Functions/GetRating.cs
+++ b/Rating/Functions/GetRating.cs
@@ -28,6 +28,16 @@ namespace Rating.Functions
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "rating/{id}")] HttpRequestData req,
             int id)
         {
+            // Handle CORS preflight requests
+            if (req.Method == "OPTIONS")
+            {
+                var corsResponse = req.CreateResponse(System.Net.HttpStatusCode.OK);
+                corsResponse.Headers.Add("Access-Control-Allow-Origin", "*");
+                corsResponse.Headers.Add("Access-Control-Allow-Methods", "GET, OPTIONS");
+                corsResponse.Headers.Add("Access-Control-Allow-Headers", "Content-Type, Authorization");
+                return corsResponse;
+            }
+            
             try
             {
                 // Validate PersonId
@@ -41,6 +51,7 @@ namespace Rating.Functions
 
                 var result = await _dataStore.FindRatingsByPersonIdAsync(id);
                 var response = req.CreateResponse(HttpStatusCode.OK);
+                response.Headers.Add("Access-Control-Allow-Origin", "*");
                 await response.WriteAsJsonAsync(RatingSummaries.CreateForPerson(id, result));
                 return response;
             }


### PR DESCRIPTION
## Changes

- Handle OPTIONS preflight requests in GetRating and GetAllRatings
- Add Access-Control-Allow-Origin headers to enable cross-origin requests
- Fixes authorization and CORS errors when querying ratings from frontend

## Why

Search endpoints (which don't require authentication) were failing with CORS errors. These changes allow the frontend to make requests to the rating API.

## Testing

Endpoints are already anonymous and available. CORS headers are now properly set.